### PR TITLE
Feature: Add TSV support for easier Excel copy-paste

### DIFF
--- a/build/constants.js
+++ b/build/constants.js
@@ -75,7 +75,8 @@ const MAXBREAKPOINT = 9999,
     ['internal_iterations', ['whole', 25, [0, 50]]],
     ['internal_revealshadows', ['yn', 'n', []]],
   ]),
-
+	SYM_USE_REMAINDER = '*',
+	SYM_FILL_MISSING = '?',
   // Some reusable regular expressions to be precompiled:
   reWholeNumber = /^\d+$/,
   reHalfNumber = /^\d+(?:\.5)?$/,
@@ -125,7 +126,18 @@ labelposition scheme per_stage
 labels relativesize 100
  magnify 100
 `,
+    // The format of a row can be in one of the formats:
+    // * `<source>[<amount>]<target>[#color[.opacity]]`
+    // * `<source>  <amount>  <target>[#color[.opacity]]`
+    // where `source` and `target` are the node names
+    // `amount` is numeric or one of the symbols `*` or `?`
+    // `color` is optional in 3 or 6 character hex
+    // `opacity` is optional in decimal form
+    // e.g. 'x [...] y #99aa00' or 'x [...] y #99aa00.25'
 
+  reFlowLine =    /^\s*(?<sourceNode>.+?)\s*(?<!\\)\[\s*(?<amount>[^\]]*?)\s*(?<!\\)\]\s*(?<targetNode>.*?)\s*(?:#\s*(?<color>[a-f0-9]{3,6})?(?<opacity>\.\d{1,4})?)?\s*$/i,
+  reTSVFlowLine = /^[ ]*(?<sourceNode>.+?)[ ]*(?<!\\)\t[ ]*(?<amount>[^\t]*?)[ ]*(?<!\\)\t[ ]*(?<targetNode>.*?)\s*(?:#\s*(?<color>[a-f0-9]{3,6})?(?<opacity>\.\d{1,4})?)?\s*$/i,
+	reCleanValue = /[^\-0-9.*?]/g,
   reNodeLine = /^:(.+) #([a-f0-9]{0,6})?(\.\d{1,4})?\s*(>>|<<)*\s*(>>|<<)*$/i,
   reFlowTargetWithSuffix = /^(.+)\s+(#\S+)$/,
 

--- a/build/sankeymatic.js
+++ b/build/sankeymatic.js
@@ -160,6 +160,46 @@ function clamp(n, min, max) {
   return isNumeric(n) ? Math.min(Math.max(Number(n), min), max) : min;
 }
 
+/**
+ * @param {string} fv A flow's value.
+ * @returns {boolean} True if the value is a special calculation symbol
+ */
+function isCalculated(fv) {
+  return [SYM_USE_REMAINDER, SYM_FILL_MISSING].includes(fv);
+}
+
+const LOCALE_USES_COMMA_AS_DECIMAL = new Intl.NumberFormat(navigator.languages).formatToParts(1.1)[1].value === ",";
+
+/**
+ * Parse a string into a number, handling locale-specific decimal separators.
+ * @param {string} value
+ * @returns {number | string | null}
+ */
+function parseAmountNumber(value) {
+  value = value.trim();
+  if (isCalculated(value)) {
+    return value;
+  }
+
+  // disambiguate the times when the value could have a comma as a decimal separator
+  // * if it has a period, use period
+  // * if it has more than one comma, use period
+  // * if it only has one comma, check the locale for confirmation
+  if (value.indexOf('.') === -1 // no `.` in the value
+    && value.indexOf(',') === value.lastIndexOf(',') // only one `,` in the value so it's ambiguous if it is thousand or decimal
+    && LOCALE_USES_COMMA_AS_DECIMAL) { // and the locale uses `,` as decimal separator
+    value = value.replace(',', '.');
+  }
+
+  value = value.replace(reCleanValue, '');
+  if (value === '') return null;
+
+  const floatValue = Number(value);
+  if (Number.isNaN(floatValue)) return null;
+
+  return floatValue;
+}
+
 // radioRef: get the object which lets you get/set a radio input value:
 function radioRef(rId) { return document.forms.skm_form.elements[rId]; }
 
@@ -2208,22 +2248,7 @@ glob.process_sankey = () => {
   //  Parse inputs into: approvedNodes, approvedFlows
   const goodFlows = [],
     approvedNodes = [],
-    approvedFlows = [],
-    SYM_USE_REMAINDER = '*',
-    SYM_FILL_MISSING = '?',
-    reFlowLine = new RegExp(
-      '^(?<sourceNode>.+)'
-      + `\\[(?<amount>[\\d\\s.+-]+|\\${SYM_USE_REMAINDER}|\\${SYM_FILL_MISSING}|)\\]`
-      + '(?<targetNodePlus>.+)$'
-    );
-
-  /**
-   * @param {string} fv A flow's value.
-   * @returns {boolean} True if the value is a special calculation symbol
-   */
-  function flowIsCalculated(fv) {
-    return [SYM_USE_REMAINDER, SYM_FILL_MISSING].includes(fv);
-  }
+    approvedFlows = [];
 
   // Loop through all the non-setting input lines:
   sourceLines.filter((l, i) => !linesWithSettings.has(i))
@@ -2248,21 +2273,28 @@ glob.process_sankey = () => {
       return;
     }
 
-    // Does this line look like a Flow?
-    matches = lineIn.match(reFlowLine);
-    if (matches !== null) {
-      const amountIn = matches[2].replace(/\s/g, ''),
-        isCalculated = flowIsCalculated(amountIn);
+    // attempt classic regex match
+    let [, source, amount, target, color, opacity] = lineIn.match(reFlowLine) || lineIn.match(reTSVFlowLine) || [];
 
+    const trialTarget = parseAmountNumber(target);
+    const trialAmount = parseAmountNumber(amount);
+    if (trialAmount === null && trialTarget !== null) {
+      target = amount;
+      amount = trialTarget;
+    }
+    else {
+      amount = trialAmount;
+    }
+    if (source && target) {
       // Is the Amount actually blank? Treat that like a comment (but log it):
-      if (amountIn === '') {
+      if (amount === '') {
         msg.log(`<span class="info_text">Skipped empty flow:</span> ${escapeHTML(lineIn)}`);
         return;
       }
 
       // Is Amount a number or a special operation?
       // Reject the line if it's neither:
-      if (!isNumeric(amountIn) && !isCalculated) {
+      if (amount === null) {
         warnAbout(
           lineIn,
           `The [Amount] must be a number in the form #.# or a wildcard ("${SYM_USE_REMAINDER}" or "${SYM_FILL_MISSING}").`
@@ -2270,19 +2302,24 @@ glob.process_sankey = () => {
         return;
       }
       // Diagrams don't currently support negative numbers:
-      if (Number(amountIn) < 0) {
+      if (Number(amount) < 0) {
         warnAbout(lineIn, 'Amounts must not be negative');
         return;
       }
 
+      color = color ? "#" + color : "";
+      opacity = opacity ? opacity : "";
+
       // All seems well, save it as good:
       goodFlows.push({
-        source: matches[1].trim(),
-        target: matches[3].trim(),
-        amount: amountIn,
+        source,
+        target,
+        amount,
         sourceRow: row,
         // Remember any special symbol even after the amount will be known:
-        operation: isCalculated ? amountIn : null,
+        operation: isCalculated(amount) ? amount : null,
+        color,
+        opacity,
       });
 
       // We need to know the maximum precision of the inputs (greatest
@@ -2290,7 +2327,7 @@ glob.process_sankey = () => {
       // checking operations (& display) later:
       maxDecimalPlaces = Math.max(
         maxDecimalPlaces,
-        (amountIn.split('.')[1] || '').length
+        ((amount + '').split('.')[1] || '').length
       );
       return;
     }
@@ -2322,30 +2359,9 @@ glob.process_sankey = () => {
         sourceRow: flow.sourceRow,
         operation: flow.operation,
         value: flow.amount,
-        color: '', // may be overwritten below
-        opacity: '', // ""
-      },
-      // Try to parse any extra info that isn't actually the target's name.
-      // The format of the Target string can be: "Name [#color[.opacity]]"
-      //   e.g. 'x [...] y #99aa00' or 'x [...] y #99aa00.25'
-      // Look for a candidate string starting with # for color info:
-      flowTargetPlus = flow.target.match(reFlowTargetWithSuffix);
-    if (flowTargetPlus !== null) {
-      // IFF the # string matches a stricter pattern, separate the target
-      // string into parts:
-      const [, possibleNodeName, possibleColor] = flowTargetPlus,
-        colorOpacity = possibleColor.match(reColorPlusOpacity);
-      if (colorOpacity !== null) {
-        // Looks like we found a color or opacity or both.
-        // Update the target's name with the trimmed string:
-        flow.target = possibleNodeName;
-        // If there was a color, adopt it:
-        if (colorOpacity[1]) { thisFlow.color = `#${colorOpacity[1]}`; }
-        // If there was an opacity, adopt it:
-        if (colorOpacity[2]) { thisFlow.opacity = colorOpacity[2]; }
-      }
-      // Otherwise we will treat it as part of the nodename, e.g. "Team #1"
-    }
+        color: flow.color,
+        opacity: flow.opacity,
+      };
 
     // Make sure the node names get saved; it may be their only appearance:
     thisFlow.source = setUpNode(flow.source, flow.sourceRow);
@@ -2433,11 +2449,11 @@ glob.process_sankey = () => {
     // We check af.value here, *not* .operation. If a calculation has been
     //   completed, we want to know that resulting amount.
     // (Note: We won't re-process flow 'ef' in this inner loop --
-    //   the 'flowIsCalculated' filter excludes its unresolved .value)
+    //   the 'isCalculated' filter excludes its unresolved .value)
     let [parentTotal, siblingTotal] = [0, 0];
     approvedFlows
       .filter(
-        (af) => !flowIsCalculated(af.value)
+        (af) => !isCalculated(af.value)
           && [af[k.arriving.node].name, af[k.leaving.node].name]
             .includes(parentN.name)
       )
@@ -2799,7 +2815,7 @@ glob.process_sankey();
 
 // Make the linter happy about imported objects:
 /* global
- d3 canvg global IN OUT BEFORE AFTER MAXBREAKPOINT
+ d3 canvg global IN OUT BEFORE AFTER MAXBREAKPOINT SYM_USE_REMAINDER SYM_FILL_MISSING
  sampleDiagramRecipes fontMetrics highlightStyles
  settingsMarker settingsAppliedPrefix settingsToBackfill
  userDataMarker sourceHeaderPrefix sourceURLLine

--- a/test/constantsProxy.mjs
+++ b/test/constantsProxy.mjs
@@ -1,0 +1,6 @@
+// this is a bit of a hack to allow minimal refactoring to the original code while supporting esm for the tests
+import { readFileSync } from 'node:fs';
+const constantsCode = readFileSync('./build/constants.js', { encoding: 'utf8' });
+
+const constants = await import('data:text/javascript;charset=utf-8,' +encodeURIComponent(constantsCode + '\n export default { reTSVFlowLine, reFlowLine };'));
+export const { reTSVFlowLine, reFlowLine } = constants.default;

--- a/test/flowLine.test.mjs
+++ b/test/flowLine.test.mjs
@@ -1,0 +1,166 @@
+// Test suite for TSV flow line parsing
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { reFlowLine } from './constantsProxy.mjs';
+
+/**
+ * Test a single flow line against the regex
+ * @param {string} input - The flow line to test
+ * @param {Object} expected - Expected match groups
+ * @param {string} expected.sourceNode - Expected source node
+ * @param {string} expected.amount - Expected amount
+ * @param {string} expected.targetNode - Expected target node
+ * @param {string} [expected.color] - Expected color (without #)
+ * @param {string} [expected.opacity] - Expected opacity
+ */
+function testFlowLine(input, expected) {
+  const match = input.match(reFlowLine);
+
+  if (!match) {
+    throw new Error(`Input did not match regex: ${JSON.stringify(input)}`);
+  }
+
+  const { groups } = match;
+
+  // Check required groups
+  assert.strictEqual(groups.sourceNode, expected.sourceNode, `Source node mismatch for: ${input} (groups: ${JSON.stringify(groups)})`);
+  assert.strictEqual(groups.amount, expected.amount, `Amount mismatch for: ${input} (groups: ${JSON.stringify(groups)})`);
+  assert.strictEqual(groups.targetNode, expected.targetNode, `Target node mismatch for: ${input} (groups: ${JSON.stringify(groups)})`);
+
+  // Check optional groups
+  if ('color' in expected) {
+    assert.strictEqual(groups.color, expected.color, `Color mismatch for: ${input} (groups: ${JSON.stringify(groups)})`);
+  } else if (groups.color !== "fff" ) { // `fff` special case for tests for convenience
+    assert.strictEqual(groups.color, undefined, `Unexpected color in: ${input}`);
+  }
+
+  if ('opacity' in expected) {
+    assert.strictEqual(groups.opacity, expected.opacity, `Opacity mismatch for: ${input} (groups: ${JSON.stringify(groups)})`);
+  } else if (groups.opacity !== ".99") { // `99` special case for tests for convenience
+    assert.strictEqual(groups.opacity, undefined, `Unexpected opacity in: ${input}`);
+  }
+}
+
+describe('Flow Line Parser', () => {
+  it('should parse basic flow line', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: '100',
+      targetNode: 'Target'
+    };
+    testFlowLine('Source[100]Target', expected);
+    testFlowLine(' Source [ 100 ] Target', expected);
+    testFlowLine('  Source [\t  100 \t]  Target  ', expected);
+  });
+
+  it('should parse with color', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: '100',
+      targetNode: 'Target',
+      color: 'ff0000'
+    };
+    testFlowLine('Source[100]Target #ff0000', expected);
+    testFlowLine('  Source[100]Target #ff0000', expected);
+    testFlowLine('  Source  [  100  ]  Target  \t  #ff0000  ', expected);
+  });
+
+  it('should parse with color and opacity', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: '100',
+      targetNode: 'Target',
+      color: 'ff0000',
+      opacity: '.75'
+    };
+    testFlowLine('Source[100]Target #ff0000.75', expected);
+    testFlowLine('  Source[100]Target #ff0000.75', expected);
+    testFlowLine('  Source  [  100  ]  Target  \t  #ff0000.75  ', expected);
+  });
+
+  it('should handle 3-digit hex colors', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: '100',
+      targetNode: 'Target',
+      color: 'f00'
+    };
+    testFlowLine('Source[100]Target #f00', expected);
+    testFlowLine('  Source[100]Target #f00', expected);
+    testFlowLine('  Source  [  100  ]  Target  \t  #f00  ', expected);
+  });
+
+    it('should parse with just opacity', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: '100',
+      targetNode: 'Target',
+      opacity: '.75'
+    };
+    testFlowLine('Source[100]Target #.75', expected);
+    testFlowLine('  Source[100]Target #.75', expected);
+    testFlowLine('  Source  [  100  ]  Target  \t  #.75  ', expected);
+  });
+
+  it('should handle empty amount', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: '',
+      targetNode: 'Target'
+    };
+    testFlowLine('Source[]Target', expected);
+    testFlowLine('  Source[]Target', expected);
+    testFlowLine('  Source  [\t  \t]Target  ', expected);
+  });
+
+  it('should handle empty target for when target and amaount are flipped', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: 'Target',
+      targetNode: ''
+    };
+    testFlowLine('Source[Target]', expected);
+    testFlowLine('Source[Target]#fff', expected);
+    testFlowLine('Source[Target]#fff.99', expected);
+    testFlowLine('  Source  [  Target  ]  #fff  ', expected);
+    testFlowLine('  Source  [  Target  ]  #fff.99  ', expected);
+  });
+
+  it('should handle opacity with 1-4 digits', () => {
+    const testCases = [
+      { input: '.1', valid: true },
+      { input: '.12', valid: true },
+      { input: '.123', valid: true },
+      { input: '.1234', valid: true },
+      { input: '.12345', valid: false },
+      { input: '1.2', valid: false }
+    ];
+
+    testCases.forEach(({ input, valid }) => {
+      const line = `Source[100]Target #${input}`;
+      const match = line.match(reFlowLine);
+
+      if (valid) {
+        assert(match, `Should match: ${line}`);
+        assert.strictEqual(match.groups.opacity, input, `Opacity should be ${input}`);
+      } else {
+        assert(!match || !match.groups.opacity, `Should not match invalid opacity: ${line}`);
+      }
+    });
+  });
+
+  it('should not match invalid color formats', () => {
+    const invalidLines = [
+      'Source[100]Target #',
+      'Source[100]Target #zzz',
+      'Source[100]Target #ff0000.',
+      'Source[100]Target #ff0000.abc',
+      'Source[100]Target #ff0000.12345'
+    ];
+
+    invalidLines.forEach(line => {
+      const match = line.match(reFlowLine);
+      assert(!match || !match.groups.color, `Should not match invalid color format: ${line}`);
+    });
+  });
+});

--- a/test/tsvFlowLine.test.mjs
+++ b/test/tsvFlowLine.test.mjs
@@ -1,0 +1,186 @@
+// Test suite for TSV flow line parsing
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { reTSVFlowLine } from './constantsProxy.mjs';
+
+/**
+ * Test a single TSV flow line against the regex
+ * @param {string} input - The TSV line to test
+ * @param {Object} expected - Expected match groups
+ * @param {string} expected.sourceNode - Expected source node
+ * @param {string} expected.amount - Expected amount
+ * @param {string} expected.targetNode - Expected target node
+ * @param {string} [expected.color] - Expected color (without #)
+ * @param {string} [expected.opacity] - Expected opacity
+ */
+function testTsvLine(input, expected) {
+  const match = input.match(reTSVFlowLine);
+
+  if (!match) {
+    throw new Error(`Input did not match regex: ${JSON.stringify(input)}`);
+  }
+
+  const { groups } = match;
+
+  // Check required groups
+  assert.strictEqual(groups.sourceNode, expected.sourceNode, `Source node mismatch for: ${input} (groups: ${JSON.stringify(groups)})`);
+  assert.strictEqual(groups.amount, expected.amount, `Amount mismatch for: ${input} (groups: ${JSON.stringify(groups)})`);
+  assert.strictEqual(groups.targetNode, expected.targetNode, `Target node mismatch for: ${input} (groups: ${JSON.stringify(groups)})`);
+
+  // Check optional groups
+  if ('color' in expected) {
+    assert.strictEqual(groups.color, expected.color, `Color mismatch for: ${input} (groups: ${JSON.stringify(groups)})`);
+  } else if (groups.color !== "fff" ) { // `fff` special case for tests for convenience
+    assert.strictEqual(groups.color, undefined, `Unexpected color in: ${input}`);
+  }
+
+  if ('opacity' in expected) {
+    assert.strictEqual(groups.opacity, expected.opacity, `Opacity mismatch for: ${input} (groups: ${JSON.stringify(groups)})`);
+  } else if (groups.opacity !== ".99") { // `99` special case for tests for convenience
+    assert.strictEqual(groups.opacity, undefined, `Unexpected opacity in: ${input}`);
+  }
+}
+
+describe('TSV Flow Line Parser', () => {
+  it('should parse basic TSV line', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: '100',
+      targetNode: 'Target'
+    };
+    testTsvLine('Source\t100\tTarget', expected);
+    testTsvLine(' Source \t 100 \t Target', expected);
+    testTsvLine('  Source \t  100 \t  Target  ', expected);
+  });
+
+  it('should parse basic TSV line with escaped tabs in fields', () => {
+    const expected = {
+      sourceNode: '\\tSource',
+      amount: '\\t100',
+      targetNode: '\\tTarget'
+    };
+    testTsvLine('\\tSource\t\\t100\t\\tTarget', expected);
+    testTsvLine('  \\tSource  \t  \\t100  \t  \\tTarget  ', expected);
+  });
+
+  it('should parse with color', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: '100',
+      targetNode: 'Target',
+      color: 'ff0000'
+    };
+    testTsvLine('Source\t100\tTarget #ff0000', expected);
+    testTsvLine('  Source\t100\tTarget #ff0000', expected);
+    testTsvLine('  Source  \t  100  \t  Target  \t  #ff0000  ', expected);
+  });
+
+  it('should parse with color and opacity', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: '100',
+      targetNode: 'Target',
+      color: 'ff0000',
+      opacity: '.75'
+    };
+    testTsvLine('Source\t100\tTarget #ff0000.75', expected);
+    testTsvLine('  Source\t100\tTarget #ff0000.75', expected);
+    testTsvLine('  Source  \t  100  \t  Target  \t  #ff0000.75  ', expected);
+  });
+
+  it('should handle 3-digit hex colors', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: '100',
+      targetNode: 'Target',
+      color: 'f00'
+    };
+    testTsvLine('Source\t100\tTarget #f00', expected);
+    testTsvLine('  Source\t100\tTarget #f00', expected);
+    testTsvLine('  Source  \t  100  \t  Target  \t  #f00  ', expected);
+  });
+
+    it('should parse with just opacity', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: '100',
+      targetNode: 'Target',
+      opacity: '.75'
+    };
+    testTsvLine('Source\t100\tTarget #.75', expected);
+    testTsvLine('  Source\t100\tTarget #.75', expected);
+    testTsvLine('  Source  \t  100  \t  Target  \t  #.75  ', expected);
+  });
+
+  it('should handle empty amount', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: '',
+      targetNode: 'Target'
+    };
+    testTsvLine('Source\t\tTarget', expected);
+    testTsvLine('  Source\t\tTarget', expected);
+    testTsvLine('  Source  \t  \tTarget  ', expected);
+  });
+
+  it('should handle empty target for when target and amaount are flipped', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: 'Target',
+      targetNode: ''
+    };
+    testTsvLine('Source\tTarget\t', expected);
+    testTsvLine('Source\tTarget\t#fff', expected);
+    testTsvLine('Source\tTarget\t#fff.99', expected);
+    testTsvLine('  Source  \t  Target  \t  #fff  \t  ', expected);
+    testTsvLine('  Source  \t  Target  \t  #fff.99  \t  ', expected);
+  });
+
+  it('should handle empty target without last tab', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: 'Target',
+      targetNode: ''
+    };
+    testTsvLine('  Source\tTarget\t', expected);
+    testTsvLine('  Source  \tTarget  \t', expected);
+  });
+
+  it('should handle opacity with 1-4 digits', () => {
+    const testCases = [
+      { input: '.1', valid: true },
+      { input: '.12', valid: true },
+      { input: '.123', valid: true },
+      { input: '.1234', valid: true },
+      { input: '.12345', valid: false },
+      { input: '1.2', valid: false }
+    ];
+
+    testCases.forEach(({ input, valid }) => {
+      const line = `Source\t100\tTarget #${input}`;
+      const match = line.match(reTSVFlowLine);
+
+      if (valid) {
+        assert(match, `Should match: ${line}`);
+        assert.strictEqual(match.groups.opacity, input, `Opacity should be ${input}`);
+      } else {
+        assert(!match || !match.groups.opacity, `Should not match invalid opacity: ${line}`);
+      }
+    });
+  });
+
+  it('should not match invalid color formats', () => {
+    const invalidLines = [
+      'Source\t100\tTarget #',
+      'Source\t100\tTarget #zzz',
+      'Source\t100\tTarget #ff0000.',
+      'Source\t100\tTarget #ff0000.abc',
+      'Source\t100\tTarget #ff0000.12345'
+    ];
+
+    invalidLines.forEach(line => {
+      const match = line.match(reTSVFlowLine);
+      assert(!match || !match.groups.color, `Should not match invalid color format: ${line}`);
+    });
+  });
+});


### PR DESCRIPTION
It's really janky to build a Sankey from Excel or Google Sheets. Ideally, we could copy-paste from three columns that have the source, target and amount columns. 

This PR adds support for tab separated definitions allowing for:
```
Wages \t 1500 \t Budget
Other \t 250 \t Budget
```

It also supports order confusion in the garget and amount columns:
```
Wages \t Budget  \t 1500
Other \t Budget \t 250
```

Additionally, it is much more lenient with the amount allowing for formatted values in a copy-paste to be gracefully handled:
* `Wages [$1,500] Budget`
* `Wages [1 500,00 €] Budget`


In an attempt to make the minimal amount of changes without wholesale refactoring, I've added tests and necessary shims for tests of the regex.

Summary of changes in the PR:
* support for TSV node definitions
* target-name and amount column confusion (swap detection)
* graceful amount detection, removing formatting
* tests for node definition regex's